### PR TITLE
Add dbg comments to profile durations in transact-method

### DIFF
--- a/src/server/waku-relayer/methods/transact-method.ts
+++ b/src/server/waku-relayer/methods/transact-method.ts
@@ -55,6 +55,7 @@ export const transactMethod = async (
 ): Promise<Optional<WakuMethodResponse>> => {
   dbg('got transact');
   dbg(params);
+  const preDecryptionTime = performance.now();
 
   const { pubkey: clientPubKey, encryptedData } = params;
 
@@ -78,6 +79,9 @@ export const transactMethod = async (
     dbg('Cannot decrypt - Not intended receiver');
     return undefined;
   }
+  const postDecryptionTime = performance.now();
+  const decryptionDuration = (postDecryptionTime - preDecryptionTime).toFixed(0);
+  dbg(`Decrypted in ${decryptionDuration}ms`);
 
   const {
     chainType,
@@ -103,7 +107,7 @@ export const transactMethod = async (
   };
 
   try {
-    dbg('Decrypted - attempting to transact');
+    dbg('Attempting to transact');
 
     if (!minVersion || !maxVersion) {
       dbg(`Cannot process tx - Requires params minVersion, maxVersion`);


### PR DESCRIPTION
## Context

Profiling the performance (total duration) of the transact method.

## Problem

The majority of the time spent hanging is/was probably due to Waku networking, but in order to be *sure* about that, we need to measure other metrics and make sure they don't get out of control.

## Solution

This PR adds a few new `dbg()` statements that report durations spent in important steps of the transact method.

## Tests

No tests ran locally, I'm trusting that CI will detect something, if any. These changes are pretty trivial.